### PR TITLE
Fix build for MinGW

### DIFF
--- a/include/sampapi/0.3.7-R1/CChat.h
+++ b/include/sampapi/0.3.7-R1/CChat.h
@@ -1,9 +1,9 @@
 /*
 	This is a SAMP (0.3.7-R1) API project file.
 	Developer: LUCHARE <luchare.dev@gmail.com>
-	
+
 	See more here https://github.com/LUCHARE/SAMP-API
-	
+
 	Copyright (c) 2018 BlastHack Team <BlastHack.Net>. All rights reserved.
 */
 
@@ -43,7 +43,7 @@ public:
     D3DCOLOR              m_debugColor; // 0xFFA9C4E4
     long                  m_nWindowBottom;
     struct SAMPAPI_EXPORT ChatEntry {
-        __int32  m_timestamp;
+        int      m_timestamp;
         char     m_szPrefix[28];
         char     m_szText[144];
         char     unused[64];

--- a/include/sampapi/0.3.7-R3-1/CChat.h
+++ b/include/sampapi/0.3.7-R3-1/CChat.h
@@ -1,9 +1,9 @@
 /*
 	This is a SAMP (0.3.7-R3) API project file.
 	Developer: LUCHARE <luchare.dev@gmail.com>
-	
+
 	See more here https://github.com/LUCHARE/SAMP-API
-	
+
 	Copyright (c) 2018 BlastHack Team <BlastHack.Net>. All rights reserved.
 */
 
@@ -45,7 +45,7 @@ public:
     long            m_nWindowBottom;
 
     struct SAMPAPI_EXPORT ChatEntry {
-        __int32  m_timestamp;
+        int      m_timestamp;
         char     m_szPrefix[28];
         char     m_szText[144];
         char     unused[64];

--- a/include/sampapi/0.3.7-R5-1/CChat.h
+++ b/include/sampapi/0.3.7-R5-1/CChat.h
@@ -1,9 +1,9 @@
 /*
 	This is a SAMP (0.3.7-R5) API project file.
 	Developers: LUCHARE <luchare.dev@gmail.com>, Northn
-	
+
 	See more here https://github.com/LUCHARE/SAMP-API
-	
+
 	Copyright (c) 2018 BlastHack Team <BlastHack.Net>. All rights reserved.
 */
 
@@ -45,7 +45,7 @@ public:
     long            m_nWindowBottom;
 
     struct SAMPAPI_EXPORT ChatEntry {
-        __int32  m_timestamp;
+        int      m_timestamp;
         char     m_szPrefix[28];
         char     m_szText[144];
         char     unused[64];

--- a/include/sampapi/sampapi.h
+++ b/include/sampapi/sampapi.h
@@ -1,9 +1,9 @@
 /*
 	This is a SAMP API project file.
 	Developer: LUCHARE <luchare.dev@gmail.com>
-	
+
 	See more here https://github.com/LUCHARE/SAMP-API
-	
+
 	Copyright (c) 2018 BlastHack Team <BlastHack.Net>. All rights reserved.
 */
 
@@ -14,8 +14,13 @@
 #endif
 #define SAMPAPI_VERSION   2
 #define SAMPAPI_NAMESPACE sampapi
-#define SAMPAPI_PACK_PUSH __pragma(pack(push, 1))
-#define SAMPAPI_PACK_POP  __pragma(pack(pop))
+#ifdef _MSC_VER
+#define SAMPAPI_PRAGMA(x) __pragma(#x)
+#else
+#define SAMPAPI_PRAGMA(x) _Pragma(#x)
+#endif
+#define SAMPAPI_PACK_PUSH SAMPAPI_PRAGMA(pack(push, 1))
+#define SAMPAPI_PACK_POP  SAMPAPI_PRAGMA(pack(pop))
 #define SAMPAPI_NAMESPACE_BEGIN(ns) \
     namespace SAMPAPI_NAMESPACE { \
         namespace ns {

--- a/include/sampapi/sampapi.h
+++ b/include/sampapi/sampapi.h
@@ -15,7 +15,7 @@
 #define SAMPAPI_VERSION   2
 #define SAMPAPI_NAMESPACE sampapi
 #ifdef _MSC_VER
-#define SAMPAPI_PRAGMA(x) __pragma(#x)
+#define SAMPAPI_PRAGMA(x) __pragma(x)
 #else
 #define SAMPAPI_PRAGMA(x) _Pragma(#x)
 #endif

--- a/src/sampapi/sampapi.cpp
+++ b/src/sampapi/sampapi.cpp
@@ -1,14 +1,14 @@
 /*
 	This is a SAMP API project file.
 	Developer: LUCHARE <luchare.dev@gmail.com>
-	
+
 	See more here https://github.com/LUCHARE/SAMP-API
-	
+
 	Copyright (c) 2018 BlastHack Team <BlastHack.Net>. All rights reserved.
 */
 
 #include "sampapi/sampapi.h"
-#include <Windows.h>
+#include <windows.h>
 
 SAMPAPI_BEGIN_COMMON
 


### PR DESCRIPTION
Fixes:
 - For nonstandard pragma `__pragma`, added GNU variant `_Pragma`
 - Changed type of `CChat::ChatEntry::m_timestamp` to `int` instead of `__int32`
 - Used lowercase, to include `<windows.h>`